### PR TITLE
feat: upgrade converter to open API 3.0 instead of swagger 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.idea

--- a/lib/conformance-to-swagger.js
+++ b/lib/conformance-to-swagger.js
@@ -23,59 +23,81 @@ var getDefaultOp = function(res) {
 }
 
 Converter.convert = function(baseURL, conf) {
-  // console.log("CS" + conf.resourceType)
-  var swagger = {swagger: '2.0'};
-  swagger.definitions = {};
+  var swagger = {openapi: '3.0.0'};
+  var definitions = {};
   swagger.paths = {};
   swagger.info = {description: DESCRIPTION, title: conf.id || 'Untitled', version: 'unspecified'};
   var url = URL.parse(baseURL);
-  swagger.host = url.host;
-  swagger.schemes = [url.protocol.substring(0, url.protocol.length - 1)];
-  swagger.basePath = url.pathname;
+  swagger.servers = [
+    {
+      url: url.href,
+      description: "staging"
+    }
+  ];
+  swagger.security = [{
+    bearerAuth: []
+  }]
+  swagger.components = {
+    schemas: definitions,
+    securitySchemes: {
+      bearerAuth: {
+        type: "http",
+        scheme: "bearer",
+        bearerFormat: "JWT"
+      }
+    }
+  }
+
   var resources = conf.rest[0].resource;
   swagger.tags = resources.map(function(res) {
     return {name: res.type};
   })
 
   resources.forEach(function(res) {
-    // console.log(res.type);
     if (!res.searchParam) return;
-    var schema = swagger.definitions[res.type] = getSchema(res);
-    var schemaRef = '#/definitions/' + res.type;
+    var schema = definitions[res.type] = getSchema(res);
+    var schemaRef = '#/components/schemas/' + res.type;
     var typeOps = swagger.paths['/' + res.type] = {};
-    var instOps = swagger.paths['/' + res.type + '/{id}'] = {parameters: [{in: 'path', required: true, name: 'id', type: 'string'}]}
+    var instOps = swagger.paths['/' + res.type + '/{id}'] = {parameters: [{in: 'path', required: true, name: 'id', schema: {type: 'string'}}]}
     res.interaction = res.interaction || DEFAULT_INTERACTIONS;
     var interactions = res.interaction.map(s => s.code);
     if (interactions.indexOf('create') !== -1) {
       typeOps.post = getDefaultOp(res);
-      typeOps.post.parameters.push({
-        name: 'body',
-        in: 'body',
-        schema: {$ref: schemaRef},
-      })
+      typeOps.post.requestBody = {
+        content: {
+          "application/json": {
+            schema: {
+              $ref: schemaRef
+            },
+          }
+        },
+        required: true
+      }
     }
     if (interactions.indexOf('search-type') !== -1) {
       typeOps.get = getDefaultOp(res);
       typeOps.get.parameters = res.searchParam.map(function(param) {
         var swagParam = {
           name: param.name,
-          type: convertType(param.type),
+          schema: {type: convertType(param.type)},
           in: 'query',
           description: param.documentation
         }
         var format = getFormat(param.type);
-        if (format) swagParam.format = format;
+        if (format) swagParam.schema.format = format;
         return swagParam;
       });
       var formatParam = {
         name: '_format',
         in: 'query',
-        type: 'string',
+        schema: {
+          type: 'string'
+        },
       }
       formatParam['x-consoleDefault'] = 'application/json';
       typeOps.get.parameters = typeOps.get.parameters.filter((v,i,a)=>a.findIndex(t=>(t.name === v.name))===i);
       typeOps.get.parameters.push(formatParam);
-      typeOps.get.responses['200'].schema = {type: 'array', items: {$ref: schemaRef}}
+      typeOps.get.responses['200'].content = {'*/*': {schema: {type: 'array', items: {$ref: schemaRef}}}}
     }
     if (interactions.indexOf('history-instance') !== -1) {
       var histOp
@@ -83,9 +105,9 @@ Converter.convert = function(baseURL, conf) {
           = {get: getDefaultOp(res)}
       histOp = histOp.get;
       histOp.parameters = [
-        {name: 'id', in: 'path', required: true, type: 'string'},
-        {name: '_count', in: 'query', type: 'string'},
-        {name: '_since', in: 'query', type: 'string'},
+        {name: 'id', in: 'path', required: true, schema: {type: 'string'}},
+        {name: '_count', in: 'query', schema: {type: 'string'}},
+        {name: '_since', in: 'query', schema: {type: 'string'}},
       ]
     }
     if (interactions.indexOf('history-type') !== -1) {
@@ -94,31 +116,36 @@ Converter.convert = function(baseURL, conf) {
           = {get: getDefaultOp(res)}
       histOp = histOp.get;
       histOp.parameters = [
-        {name: '_count', in: 'query', type: 'string'},
-        {name: '_since', in: 'query', type: 'string'},
+        {name: '_count', in: 'query', schema: {type: 'string'}},
+        {name: '_since', in: 'query', schema: {type: 'string'}},
       ]
     }
 
     if (interactions.indexOf('read') !== -1) {
       instOps.get = getDefaultOp(res);
-      instOps.get.responses['200'].schema = {$ref: schemaRef};
+      instOps.get.responses['200'].content = {'*/*': {schema: {$ref: schemaRef}}};
     }
     if (interactions.indexOf('vread') !== -1) {
       var versionOp = swagger.paths['/' + res.type + '/{id}/_history/{vid}'] = {get: getDefaultOp(res)};
       versionOp = versionOp.get;
       versionOp.parameters = [
-        {name: 'id', in: 'path', required: true, type: 'string'},
-        {name: 'vid', in: 'path', required: true, type: 'string'},
+        {name: 'id', in: 'path', required: true, schema: {type: 'string'}},
+        {name: 'vid', in: 'path', required: true, schema: {type: 'string'}},
       ];
-      versionOp.responses['200'].schema = {$ref: schemaRef};
+      versionOp.responses['200'].content = {'*/*': {schema: {$ref: schemaRef}}};
     }
     if (interactions.indexOf('update') !== -1) {
       instOps.put = getDefaultOp(res);
-      instOps.put.parameters.push({
-        in: 'body',
-        name: 'body',
-        schema: {$ref: schemaRef}
-      })
+      instOps.put.requestBody = {
+        content: {
+          "application/json": {
+            schema: {
+              $ref: schemaRef
+            },
+          }
+        },
+        required: true
+      }
     }
     if (interactions.indexOf('delete') !== -1) {
       instOps.delete = getDefaultOp(res);


### PR DESCRIPTION
Le converter utilisé par la lib historiquement gérait du swagger 2.0
Or avec notre authent par token JWT nous avions besoin des nouvelles fonctionnalités de la version open API 3.0 qui propose d'ajouter une authorization par token JWT

Cette PR permet de faire l'upgrade à la V3 en modifiant les champs necessaires.
Cette PR ajoute également le moyen de s'authentifié par JWT dans la UI de manière globale sinon 401 lors des call API